### PR TITLE
hotfix/TOPS-800: Renaming gsoft-inc organization to workleap in github.

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,7 +39,7 @@ jobs:
 
   linearb:
     needs: [deploy]
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/linearb-deployment.yml@main
     with:
       environment: release
     secrets: inherit

--- a/.github/workflows/jira.yml
+++ b/.github/workflows/jira.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-workflow-jira:
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-jira-workflow.yml@main
     with:
       branch_name: ${{ github.head_ref }}
     secrets: inherit

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -12,4 +12,4 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    uses: gsoft-inc/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main
+    uses: workleap/wl-reusable-workflows/.github/workflows/reusable-semgrep-workflow.yml@main

--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ helm upgrade --install --atomic --cleanup-on-fail --debug --dependency-update [.
 
 ## License
 
-Copyright © 2023, GSoft Group Inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/gsoft-inc/gsoft-license/blob/master/LICENSE.
+Copyright © 2023, GSoft Group Inc. This code is licensed under the Apache License, Version 2.0. You may obtain a copy of this license at https://github.com/workleap/gsoft-license/blob/master/LICENSE.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dependencies:
   - name: aspnetcore
     alias: aspnetcore
     version: 2.0.0
-    repository: https://gsoft-inc.github.io/gsoft-helm-charts
+    repository: https://workleap.github.io/gsoft-helm-charts
 ```
 
 Then, in your `values.yaml` file, override the default values:
@@ -50,7 +50,7 @@ helm upgrade --install --atomic --cleanup-on-fail --debug --dependency-update [.
 * Create a pull request and go through the review process.
 * When the pull request is merged back in the main branch, the following workflows are automatically triggered:
   1. [Release charts](.github/workflows/release-charts.yml): packages the updated chart, creates a GitHub release and updates the public Helm [index.yaml](pages/index.yaml) repository file. This has no effect if no chart version was changed.
-  2. [Deploy pages](.github/workflows/deploy-pages.yml): deploy the latest [index.yaml](https://gsoft-inc.github.io/gsoft-helm-charts/index.yaml) file to GitHub Pages.
+  2. [Deploy pages](.github/workflows/deploy-pages.yml): deploy the latest [index.yaml](https://workleap.github.io/gsoft-helm-charts/index.yaml) file to GitHub Pages.
 
 
 ## License

--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
 version: 3.0.2
-home: https://github.com/gsoft-inc/gsoft-helm-charts
+home: https://github.com/workleap/gsoft-helm-charts
 sources:
-  - https://github.com/gsoft-inc/gsoft-helm-charts
+  - https://github.com/workleap/gsoft-helm-charts
 maintainers:
   - name: Workleap
     url: https://www.workleap.com

--- a/pages/index.yaml
+++ b/pages/index.yaml
@@ -5,196 +5,196 @@ entries:
     created: "2025-02-12T20:07:43.699049046Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: d3d2c34c42d9452da57dcf5222e25647625e3f9cd2e1ed5684a45ece95eda463
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: Workleap
       url: https://www.workleap.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-3.0.2/aspnetcore-3.0.2.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-3.0.2/aspnetcore-3.0.2.tgz
     version: 3.0.2
   - apiVersion: v2
     created: "2024-12-17T15:04:25.744111239Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: bc998dfa899a107413bfe0615159b2dd0bdc88a48ea6286004575156e4a19beb
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-3.0.1/aspnetcore-3.0.1.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-3.0.1/aspnetcore-3.0.1.tgz
     version: 3.0.1
   - apiVersion: v2
     created: "2024-12-11T15:49:38.000698384Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: eb2067116be1481f3a406e0d22411dc730b5889c9bd8a1e53f3ebe4a34734e76
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-3.0.0/aspnetcore-3.0.0.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-3.0.0/aspnetcore-3.0.0.tgz
     version: 3.0.0
   - apiVersion: v2
     created: "2024-12-09T20:35:25.381962412Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: cd56c814eb6c2f8a4d9f1a70999001e423cf013d267c9a0a1fb6fd96b7100a62
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-2.3.0/aspnetcore-2.3.0.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-2.3.0/aspnetcore-2.3.0.tgz
     version: 2.3.0
   - apiVersion: v2
     created: "2024-10-17T19:04:26.896498049Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 94fa35dd028a37dd8a06cf3460a3c41f7cceccc0a3650e6114003745608ed1e0
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-2.2.0/aspnetcore-2.2.0.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-2.2.0/aspnetcore-2.2.0.tgz
     version: 2.2.0
   - apiVersion: v2
     created: "2024-10-09T17:42:04.460935693Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 6b6ef1937729ded2c4851897062368fd2b8ad331bcb52ed78ec8b0024b9698aa
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-2.1.1/aspnetcore-2.1.1.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-2.1.1/aspnetcore-2.1.1.tgz
     version: 2.1.1
   - apiVersion: v2
     created: "2024-09-06T14:45:56.601168004Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 7112b733228171238eac7c9356f3d528864fc1367902d5819ba777deb42b3f79
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-2.1.0/aspnetcore-2.1.0.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-2.1.0/aspnetcore-2.1.0.tgz
     version: 2.1.0
   - apiVersion: v2
     created: "2024-05-27T13:55:48.65013441Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 31b037626187ae77479b59bbbe162b20d61066c6680165a904175905a352f274
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-2.0.0/aspnetcore-2.0.0.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-2.0.0/aspnetcore-2.0.0.tgz
     version: 2.0.0
   - apiVersion: v2
     created: "2024-05-15T20:35:47.29681995Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 30c7c82d86327b337a07af0099ba5f25568244a14c2999a7912a6e9d5bec65c1
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-1.0.6/aspnetcore-1.0.6.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-1.0.6/aspnetcore-1.0.6.tgz
     version: 1.0.6
   - apiVersion: v2
     created: "2024-05-15T19:21:21.174278113Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 012a188829525413dd8e9f0254f0f8623e14af7bc1079d9072acee722fcf971c
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-1.0.5/aspnetcore-1.0.5.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-1.0.5/aspnetcore-1.0.5.tgz
     version: 1.0.5
   - apiVersion: v2
     created: "2024-05-09T13:07:14.472132207Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: e2ddaf2b8a075fa9c21a7f103f7e0803ae0d2454ae15fb02e4a99c0335ed0810
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-1.0.4/aspnetcore-1.0.4.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-1.0.4/aspnetcore-1.0.4.tgz
     version: 1.0.4
   - apiVersion: v2
     created: "2024-05-07T20:46:11.368228449Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 8b3a5dd8363459c4811b61630ab47fda5a6c7ef20d635bac2acb707aa1086205
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-1.0.3/aspnetcore-1.0.3.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-1.0.3/aspnetcore-1.0.3.tgz
     version: 1.0.3
   - apiVersion: v2
     created: "2024-04-03T20:53:53.348836967Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: bb055b115417b710dff20e7644bf86df4501aca38a9d9325f065d46aca4c5679
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-1.0.1/aspnetcore-1.0.1.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-1.0.1/aspnetcore-1.0.1.tgz
     version: 1.0.1
   - apiVersion: v2
     created: "2023-03-13T19:29:24.125973597Z"
     description: A generic Helm chart for ASP.NET Core services
     digest: 171cb2ff79bda3ff008d59c79c1b90743b1ad0ad148a58d8b79309c0db1d5ccd
-    home: https://github.com/gsoft-inc/gsoft-helm-charts
+    home: https://github.com/workleap/gsoft-helm-charts
     maintainers:
     - name: GSoft Group Inc.
       url: https://www.gsoft.com
     name: aspnetcore
     sources:
-    - https://github.com/gsoft-inc/gsoft-helm-charts
+    - https://github.com/workleap/gsoft-helm-charts
     urls:
-    - https://github.com/gsoft-inc/gsoft-helm-charts/releases/download/aspnetcore-1.0.0/aspnetcore-1.0.0.tgz
+    - https://github.com/workleap/gsoft-helm-charts/releases/download/aspnetcore-1.0.0/aspnetcore-1.0.0.tgz
     version: 1.0.0
 generated: "2025-02-12T20:07:43.699191711Z"


### PR DESCRIPTION
TOPS-800: Replacing gsoft-inc/wl-reusable-workflows by workleap/wl-reusable-workflows

--
Not sure why this PR has been created? Reach TechOps in our public slack channel: #techops-and-friends
Some context on the why of this PR can be found here: https://workleap.slack.com/archives/C02E9KPRQ7P/p1737385211295479 