### PR TITLE
Enable bringing custom selectors to ease migrations to the templates

### DIFF
--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -15,7 +15,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "aspnetcore.selectorLabels" . | nindent 6 }}
+      {{- if .Values.migration.existingSelectors.enabled }}
+        {{- toYaml .Values.migration.existingSelectors.selectors | nindent 6 }}
+      {{- else }}
+        {{ include "aspnetcore.selectorLabels" . | nindent 6 }}
+      {{- end }}
   template:
     metadata:
       labels:

--- a/charts/aspnetcore/templates/service.yaml
+++ b/charts/aspnetcore/templates/service.yaml
@@ -22,4 +22,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "aspnetcore.selectorLabels" . | nindent 4 }}
+    {{- if .Values.customSelectors }}
+    {{ toYaml .Values.customSelectors | nindent 4 }}
+    {{- else }}
+    {{ include "aspnetcore.selectorLabels" . | nindent 4 }}
+    {{- end }}

--- a/charts/aspnetcore/templates/service.yaml
+++ b/charts/aspnetcore/templates/service.yaml
@@ -22,8 +22,8 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- if .Values.customSelectors }}
-    {{ toYaml .Values.customSelectors | nindent 4 }}
+      {{- if .Values.migration.existingSelectors.enabled }}
+      {{- toYaml .Values.migration.existingSelectors.selectors | nindent 4 }}
     {{- else }}
     {{ include "aspnetcore.selectorLabels" . | nindent 4 }}
     {{- end }}

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -232,3 +232,11 @@ securityContext:
     value: "30"
   - name: net.ipv4.tcp_keepalive_probes
     value: "8"
+
+## Configure settings related to HELM chart migration.
+## @param migration.existingSelectors.enabled Whether or not to use existing selectors for the deployment
+## @param migration.existingSelectors.selectors A map of existing selectors to use for the deployment
+migration:
+  existingSelectors:
+    enabled: false
+    selectors: {}


### PR DESCRIPTION
New input parameters have been added to the Helm template, enabling custom selector labels to facilitate seamless migrations.