### PR TITLE
feat: add topologySpreadConstraints with node spread enabled by default

### DIFF
--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -46,7 +46,23 @@ spec:
       securityContext:
         sysctls:
           {{- toYaml .Values.securityContext.sysctls | nindent 10 }}
-      {{- end }}   
+      {{- end }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      {{- else if .Values.presets.spreadAcrossNodes.enabled }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- if .Values.migration.existingSelectors.enabled }}
+                {{- toYaml .Values.migration.existingSelectors.selectors | nindent 14 }}
+              {{- else }}
+                {{ include "aspnetcore.selectorLabels" . | nindent 14 }}
+              {{- end }}
+      {{- end }}
       serviceAccountName: {{ include "aspnetcore.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -147,6 +147,11 @@ nodeSelector: {}
 ##
 tolerations: []
 
+## @param topologySpreadConstraints for pods
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+## notes: Setting the topologySpreadConstraints will override the helm chart's `spreadAcrossNodes` preset
+topologySpreadConstraints: []
+
 ## Kubernetes service account
 ## @param serviceAccount.create Specifies whether a ServiceAccount should be created
 ## @param serviceAccount.name The name of the ServiceAccount to use, even if "create" is false
@@ -240,3 +245,10 @@ migration:
   existingSelectors:
     enabled: false
     selectors: {}
+
+## Handles more complex configurations in an opiniated way
+presets:
+  ## Configure a `topologySpreadConstraints` for the deployment spreading pods across nodes in a best effort way
+  ## Setting the chart Values.topologySpreadConstraints will override this preset
+  spreadAcrossNodes:
+    enabled: true


### PR DESCRIPTION
Add possibility to add topologySpreadConstraints to deployments

Provide preset for best-effort node spreading

Enable best-effort node-spread by default
