### PR TITLE
feat: [FENG-190] - Add Workleap annotations including git repo url

### DIFF
--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 3.1.0
+version: 3.2.0
 home: https://github.com/workleap/gsoft-helm-charts
 sources:
   - https://github.com/workleap/gsoft-helm-charts

--- a/charts/aspnetcore/Chart.yaml
+++ b/charts/aspnetcore/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: aspnetcore
 description: A generic Helm chart for ASP.NET Core services
-version: 3.2.0
+version: 4.0.0
 home: https://github.com/workleap/gsoft-helm-charts
 sources:
   - https://github.com/workleap/gsoft-helm-charts

--- a/charts/aspnetcore/templates/_helpers.tpl
+++ b/charts/aspnetcore/templates/_helpers.tpl
@@ -20,3 +20,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/* Standard Workleap annotations */}}
+{{- define "workleap.standardAnnotations" -}}
+workleap.com/git: {{ .Values.gitRepoUrl }}
+{{- end }}

--- a/charts/aspnetcore/templates/_helpers.tpl
+++ b/charts/aspnetcore/templates/_helpers.tpl
@@ -23,5 +23,5 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{/* Standard Workleap annotations */}}
 {{- define "workleap.standardAnnotations" -}}
-workleap.com/git: {{ .Values.gitRepoUrl }}
+workleap.com/git: {{ .Values.git.url }}
 {{- end }}

--- a/charts/aspnetcore/templates/deployment-hpa.yaml
+++ b/charts/aspnetcore/templates/deployment-hpa.yaml
@@ -9,8 +9,9 @@ metadata:
       {{- toYaml .Values.commonLabels | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-      {{- toYaml . | nindent 4 }}
+    {{- include "workleap.standardAnnotations" . | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
 spec:
   metrics:

--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -8,8 +8,9 @@ metadata:
       {{- toYaml .Values.commonLabels | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-      {{- toYaml . | nindent 4 }}
+    {{- include "workleap.standardAnnotations" . | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}

--- a/charts/aspnetcore/templates/ingress.yaml
+++ b/charts/aspnetcore/templates/ingress.yaml
@@ -12,8 +12,9 @@ metadata:
     {{- with .Values.ingress.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.commonAnnotations }}
-      {{- toYaml . | nindent 4 }}
+    {{- include "workleap.standardAnnotations" . | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.className }}

--- a/charts/aspnetcore/templates/podidentity.yaml
+++ b/charts/aspnetcore/templates/podidentity.yaml
@@ -9,8 +9,9 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
   annotations:
-    {{- with .Values.commonAnnotations }}
-      {{- toYaml . | nindent 4 }}
+    {{- include "workleap.standardAnnotations" . | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
 spec:
   azureIdentity: {{ .Values.aadPodIdentityBinding.identityName }}

--- a/charts/aspnetcore/templates/prechecks.tpl
+++ b/charts/aspnetcore/templates/prechecks.tpl
@@ -7,3 +7,7 @@
         {{- end }}
     {{- end }}
 {{- end }}
+
+{{- if not .Values.gitRepoUrl }}
+    {{- fail "gitRepoUrl is required" }}
+{{- end }}

--- a/charts/aspnetcore/templates/prechecks.tpl
+++ b/charts/aspnetcore/templates/prechecks.tpl
@@ -8,6 +8,6 @@
     {{- end }}
 {{- end }}
 
-{{- if not .Values.gitRepoUrl }}
-    {{- fail "gitRepoUrl is required" }}
+{{- if not .Values.git.url }}
+    {{- fail "git.url is required" }}
 {{- end }}

--- a/charts/aspnetcore/templates/service.yaml
+++ b/charts/aspnetcore/templates/service.yaml
@@ -11,8 +11,9 @@ metadata:
     {{- with .Values.service.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.commonAnnotations }}
-      {{- toYaml . | nindent 4 }}
+    {{- include "workleap.standardAnnotations" . | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
 spec:
   type: ClusterIP

--- a/charts/aspnetcore/templates/serviceaccount.yaml
+++ b/charts/aspnetcore/templates/serviceaccount.yaml
@@ -22,7 +22,8 @@ metadata:
     {{- with .Values.serviceAccount.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.commonAnnotations }}
-      {{- toYaml . | nindent 4 }}
+    {{- include "workleap.standardAnnotations" . | nindent 4 }}
+    {{- if .Values.commonAnnotations }}
+      {{- toYaml .Values.commonAnnotations | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -10,6 +10,11 @@ terminationGracePeriodSeconds: 30
 ##
 environment: Development
 
+git: {
+  ## @param url The URL of the git repository; Required.
+  url: ""
+}
+
 ## @param commonLabels Labels to add to all deployed objects
 ##
 commonLabels: {}


### PR DESCRIPTION
Right now, it’s hard to track down all the created kubernetes resources to a specific team/owner (at least for me). If you want to make changes to said resources, you have to know in which repository are defined the values.yaml files.

We should accept a git repository url as a chart value so that we can add an annotation creating this missing link. (ps: the same kind of thing could be done for resources deployed through terraform, etc.).

Up to debate: Should the git repo url be required ? I think so, but this will lead to breaking changes for product teams… they will have to add the git repo to their `values.yaml` file. UNLESS… they are also rolling out the helm deployment using a shared ci/cd job in which we could pass as a helm update argument a --set git.url=${CICD_SOURCE_REPOSITORY_MAGIC_VARIABLE_THAT_I_HOPE_IS_AVAILABLE_IN_AZURE_DEVOPS}

>NOTE: If breaking change, bump chart version to 4.0.0; else bump to 3.2.0