### PR TITLE
#major [FENG-295] fix: disable automountServiceAccountToken

### DIFF
--- a/charts/aspnetcore/templates/deployment.yaml
+++ b/charts/aspnetcore/templates/deployment.yaml
@@ -63,6 +63,12 @@ spec:
                 {{ include "aspnetcore.selectorLabels" . | nindent 14 }}
               {{- end }}
       {{- end }}
+      {{- if .Values.aadPodIdentityBinding.create }}
+      # Kubernetes API access required when using the deprecated aadPodIdentityBinding
+      automountServiceAccountToken: true
+      {{- else }}
+      automountServiceAccountToken: false
+      {{- end }}
       serviceAccountName: {{ include "aspnetcore.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:

--- a/charts/aspnetcore/values.yaml
+++ b/charts/aspnetcore/values.yaml
@@ -162,7 +162,7 @@ serviceAccount:
   name: ""
   annotations: {}
 
-## Azure AD Pod Identity binding (https://github.com/Azure/aad-pod-identity)
+## Azure AD Pod Identity binding (https://github.com/Azure/aad-pod-identity) - Deprecated since October 24, 2022; use azureWorkloadIdentity instead
 ## @param aadPodIdentityBinding.create Whether or not to create an AAD pod identity binding associated to the deployment
 ## @param aadPodIdentityBinding.name Name of the AAD pod identity binding, automatically generated from the release name if not specified
 ## @param aadPodIdentityBinding.identityName Name of the AAD identity


### PR DESCRIPTION
For security purpose, we should disable the mounting of the service account token in our workloads. There is no need for them to reach out to the Kubernetes API.

The exception is if using the deprecated `Azure AD Pod Identity binding` which needs API access.
