### PR TITLE
Update checkout action to v5 and modify token

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.HELM_PAT }}
+          #token: ${{ secrets.HELM_PAT }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
Jira issue link: [FESD-435](https://workleap.atlassian.net/browse/FESD-435)

This pull request makes a minor update to the workflow configuration by upgrading the GitHub Actions checkout version and commenting out the use of a personal access token.

* Upgraded the `actions/checkout` step in `.github/workflows/release-charts.yml` from a specific commit hash (v4) to the latest major version (v5), and commented out the use of the `HELM_PAT` token.

[FESD-435]: https://workleap.atlassian.net/browse/FESD-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ