### PR TITLE
fix: remove environment value validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,11 +132,10 @@ tests/schema/termination-grace-period-negative: export EXPECTED_ERROR_MESSAGE="(
 tests/schema/termination-grace-period-negative:
 	@${HELM_TEMPLATE} --set terminationGracePeriodSeconds=-1 ${SHOULD_FAIL_WITH_ERROR_AND_THEN} ${DISPLAY_RESULT}
 
-# Test environment enum validation (should fail with invalid environment)
-tests/schema/environment-invalid: export TEST_DISPLAY_NAME="Schema should reject invalid environment values"
-tests/schema/environment-invalid: export EXPECTED_ERROR_MESSAGE="(environment.*|Must be one of the following)"
-tests/schema/environment-invalid:
-	@${HELM_TEMPLATE} --set environment="Invalid" ${SHOULD_FAIL_WITH_ERROR_AND_THEN} ${DISPLAY_RESULT}
+# Test environment accepts any value
+tests/schema/environment-valid: export TEST_DISPLAY_NAME="Schema should accept any environment value"
+tests/schema/environment-valid:
+	@${HELM_TEMPLATE} --set environment="Whatever" ${SHOULD_SUCCEED_AND_THEN} ${DISPLAY_RESULT}
 
 # Test environment valid values (should pass)
 tests/schema/environment-valid: export TEST_DISPLAY_NAME="Valid environment should be accepted"

--- a/charts/aspnetcore/tests/integration/chart/values.yaml
+++ b/charts/aspnetcore/tests/integration/chart/values.yaml
@@ -15,6 +15,8 @@ aspnetcore:
       nginx.ingress.kubernetes.io/rewrite-target: /$2
       nginx.ingress.kubernetes.io/x-forwarded-prefix: /leap.shop
 
+  environment: stg
+
   resources:
     limits:
       memory: "128Mi"

--- a/charts/aspnetcore/values.schema.json
+++ b/charts/aspnetcore/values.schema.json
@@ -19,8 +19,7 @@
     "environment": {
       "type": "string",
       "default": "Development",
-      "description": "The ASP.NET Core environment name (DOTNET_ENVIRONMENT)",
-      "enum": ["Development", "Staging", "Production"]
+      "description": "The ASP.NET Core environment name (DOTNET_ENVIRONMENT)"
     },
     "commonLabels": {
       "type": "object",


### PR DESCRIPTION
Upon research, some teams uses full names (Development|Staging|Production) while other uses abbreviations (dev|stg|prod).

Remove any validation for the environment and let team set whatever they want